### PR TITLE
docs: describe Atlas Cloud as a model provider on OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Click the diagram to view the full-resolution architecture image.
   <img src="ui/public/atlas-cloudXopenagent.jpg" alt="Atlas Cloud" width="560" />
 </p>
 
-- Atlas Cloud is now available as an OpenAI-compatible provider with `ATLASCLOUD_API_KEY` and `ATLASCLOUD_API_BASE`.
+- Atlas Cloud is a model provider on OpenRouter. Integrate it in this project via `ATLASCLOUD_API_KEY` and `ATLASCLOUD_API_BASE`.
 - Official website: [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=openagent)
 - Integration docs: [https://www.atlascloud.ai/docs](https://www.atlascloud.ai/docs)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -85,7 +85,7 @@ OpenAgent 不是单一的聊天 Demo，而是一个面向团队和产品化场�
   <img src="ui/public/atlas-cloudXopenagent.jpg" alt="Atlas Cloud" width="560" />
 </p>
 
-- Atlas Cloud 现已作为 OpenAI 兼容提供商可用，可通过 `ATLASCLOUD_API_KEY` 和 `ATLASCLOUD_API_BASE` 接入。
+- Atlas Cloud 是 OpenRouter 的模型提供商。本项目可通过 `ATLASCLOUD_API_KEY` 和 `ATLASCLOUD_API_BASE` 接入。
 - 官方网站：[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=openagent)
 - 接入文档：[https://www.atlascloud.ai/docs](https://www.atlascloud.ai/docs)
 


### PR DESCRIPTION
## Description

将 `README.md` 与 `README_ZH.md` 中 Atlas Cloud 赞助商说明由 "OpenAI-compatible provider" 调整为 "a model provider on OpenRouter"，更准确地反映 Atlas Cloud 在 OpenRouter 生态中的定位。本项目接入方式不变，仍使用 `ATLASCLOUD_API_KEY` 与 `ATLASCLOUD_API_BASE`。

## Related Issue

Closes #

## Motivation and Context

原描述 "OpenAI-compatible provider" 未能体现 Atlas Cloud 作为 OpenRouter 模型提供商的定位。本次仅调整措辞，使赞助商介绍更准确，不涉及任何代码或环境变量变更。

## Type of Change

- [x] `docs` — Documentation only

## Changes Made

- `README.md`：第 88 行 `OpenAI-compatible provider` → `a model provider on OpenRouter`
- `README_ZH.md`：第 88 行 `OpenAI 兼容提供商` → `OpenRouter 的模型提供商`
- 环境变量 `ATLASCLOUD_API_KEY` / `ATLASCLOUD_API_BASE` 保持不变，与代码实现一致

## How to Test

1. 在 GitHub 或 Markdown 预览器中打开 `README.md` 第 80–90 行，确认 Atlas Cloud 区块第 88 行显示为 "a model provider on OpenRouter"
2. 打开 `README_ZH.md` 第 80–90 行，确认显示为 "OpenRouter 的模型提供商"
3. 确认 `ATLASCLOUD_API_KEY` / `ATLASCLOUD_API_BASE` 环境变量名未改动，与 `api/.env.example` 及 `api/internal/core/language_model/providers/atlascloud/chat.py` 一致

## Impact

- [x] Documentation

## Checklist

- [x] I have self-reviewed my code.
- [x] My code follows the project style (Conventional Commits).
- [x] I have added or updated tests for changed behavior. (N/A — docs only)
- [x] Tests pass. (N/A — docs only, no code change)
- [x] Quality gates pass. (N/A — docs only, no code change)
- [x] I have NOT committed secrets, tokens, or `.env` files.
- [x] My commits follow Conventional Commits.
- [x] I have updated documentation where relevant.
